### PR TITLE
Remove app header; disable QR trigger

### DIFF
--- a/hat-app/src/App.css
+++ b/hat-app/src/App.css
@@ -9,30 +9,6 @@
   overflow: hidden;
 }
 
-.app-header {
-  position: absolute;
-  top: 0;
-  left: 0;
-  right: 0;
-  z-index: 10;
-  padding: 16px 20px;
-  background: linear-gradient(to bottom, rgba(0, 0, 0, 0.8), transparent);
-  pointer-events: none;
-}
-
-.app-header h1 {
-  color: white;
-  font-size: 24px;
-  font-weight: 700;
-  margin-bottom: 4px;
-}
-
-.subtitle {
-  color: rgba(255, 255, 255, 0.7);
-  font-size: 14px;
-  font-weight: 400;
-}
-
 .app-main {
   flex: 1;
   width: 100%;
@@ -42,33 +18,4 @@
   overflow: hidden;
 }
 
-/* Mobile optimizations */
-@media (max-width: 768px) {
-  .app-header {
-    padding: 12px 16px;
-  }
-
-  .app-header h1 {
-    font-size: 20px;
-  }
-
-  .subtitle {
-    font-size: 12px;
-  }
-}
-
-/* Landscape orientation on mobile */
-@media (max-width: 768px) and (orientation: landscape) {
-  .app-header {
-    padding: 8px 16px;
-  }
-
-  .app-header h1 {
-    font-size: 18px;
-  }
-
-  .subtitle {
-    font-size: 11px;
-  }
-}
 

--- a/hat-app/src/App.jsx
+++ b/hat-app/src/App.jsx
@@ -5,10 +5,6 @@ import './App.css'
 function App() {
   return (
     <div className="app">
-      <header className="app-header">
-        <h1>AR Hat App</h1>
-        <p className="subtitle">Face tracking + AR overlay</p>
-      </header>
       <main className="app-main">
         <CameraFeed />
       </main>

--- a/hat-app/src/components/Camera/CameraFeed.jsx
+++ b/hat-app/src/components/Camera/CameraFeed.jsx
@@ -45,7 +45,7 @@ export default function CameraFeed() {
   const [sphereDepth, setSphereDepth] = useState(0.95)
   const [testQRResult, setTestQRResult] = useState(null)
   const [showQRDebugFrame, setShowQRDebugFrame] = useState(false)
-  const [useQRTrigger, setUseQRTrigger] = useState(true)
+  const [useQRTrigger, setUseQRTrigger] = useState(false)
   const [controlsOpen, setControlsOpen] = useState(false)
   const testFileInputRef = useRef(null)
   const qrDebugCanvasRef = useRef(null)


### PR DESCRIPTION
Remove the top header UI and its CSS to simplify the app layout: deleted the .app-header styles and responsive rules from App.css and removed the header element from App.jsx. Also change CameraFeed default state for useQRTrigger from true to false to disable automatic QR triggering by default (reduces accidental scans / requires explicit enable). Files changed: hat-app/src/App.css, hat-app/src/App.jsx, hat-app/src/components/Camera/CameraFeed.jsx.