### PR TITLE
Update Bilista project dates to 2023

### DIFF
--- a/projects/bilista.html
+++ b/projects/bilista.html
@@ -29,7 +29,7 @@
 
         <!-- 1. Hero -->
         <section class="project-section project-section--hero">
-            <p class="eyebrow">Bilista · EGGS Design · Oslo, Norway · 2022 – Present</p>
+            <p class="eyebrow">Bilista · EGGS Design · Oslo, Norway · 2022 – 2023</p>
             <h1 class="hero-headline">From concept to market — Norway's private mobility platform</h1>
             <figure class="media-frame media-frame--hero">
                 <picture>
@@ -53,7 +53,7 @@
         <section class="project-section">
             <div class="section-grid">
                 <div class="section-text">
-                    <p class="eyebrow">Joined April 2022 — Current</p>
+                    <p class="eyebrow">Joined April 2022 — 2023</p>
                     <h2 class="section-title">My Role</h2>
                     <p class="section-body">
                         My role spanned the full design cycle: leading UX and UI, running user research and


### PR DESCRIPTION
Change date references in projects/bilista.html from '2022 – Present' and 'Joined April 2022 — Current' to '2022 – 2023' and 'Joined April 2022 — 2023' to reflect the project end year.